### PR TITLE
Bugfix nodetype

### DIFF
--- a/Classes/Domain/Form/FormLocator.php
+++ b/Classes/Domain/Form/FormLocator.php
@@ -43,9 +43,11 @@ class FormLocator
             )
         );
 
+        $formTitle = $formNode->getProperty('formTitle') ?? $formNode->getLabel();
+
         return new self(
             $formId,
-            $formNode->getProperty('title'),
+            $formTitle,
             $path
         );
     }

--- a/NodeTypes/Mixin/ExportableForm.yaml
+++ b/NodeTypes/Mixin/ExportableForm.yaml
@@ -9,14 +9,14 @@
           position: start 10
 
   properties:
-    title:
+    formTitle:
       type: string
       ui:
         label: 'Form Titel'
         inspector:
           group: export
-      validation:
-        'Neos.Neos/Validation/NotEmptyValidator': { }
+          editorOptions:
+            placeholder: 'ClientEval: node.label'
     isExportable:
       type: boolean
       defaultValue: false

--- a/NodeTypes/Mixin/ExportableForm.yaml
+++ b/NodeTypes/Mixin/ExportableForm.yaml
@@ -13,7 +13,7 @@
       type: boolean
       defaultValue: false
       ui:
-        label: "Exportable"
+        label: 'Exportable'
         inspector:
           group: export
           position: 10

--- a/NodeTypes/Mixin/ExportableForm.yaml
+++ b/NodeTypes/Mixin/ExportableForm.yaml
@@ -4,19 +4,11 @@
     inspector:
       groups:
         export:
-          label: 'Export'
+          label: 'Form Export'
           icon: archive
           position: start 10
 
   properties:
-    formTitle:
-      type: string
-      ui:
-        label: 'Form Titel'
-        inspector:
-          group: export
-          editorOptions:
-            placeholder: 'ClientEval: node.label'
     isExportable:
       type: boolean
       defaultValue: false
@@ -24,19 +16,31 @@
         label: "Exportable"
         inspector:
           group: export
+          position: 10
+    formTitle:
+      type: string
+      ui:
+        label: 'Form Title'
+        inspector:
+          group: export
+          position: 20
+          hidden: 'ClientEval: !node.properties.isExportable'
+          editorOptions:
+            placeholder: 'ClientEval: node.label'
     excludedFields:
       type: array
       ui:
-        label: "Excluded Fields"
+        label: 'Excluded Fields'
         help:
-          message: "Field names which must be excluded from export"
+          message: 'Field names which must be excluded from export'
         inspector:
           group: export
           editor: Sitegeist.InspectorGadget/Inspector/Editor
+          position: 30
+          hidden: 'ClientEval: !node.properties.isExportable'
           editorOptions:
             isCollection: true
             isSortable: true
             itemType: Sitegeist\StoneTablet\Domain\Field
             labels:
               addItem: 'Add Field'
-

--- a/NodeTypes/Mixin/ExportableForm.yaml
+++ b/NodeTypes/Mixin/ExportableForm.yaml
@@ -1,8 +1,5 @@
 'Sitegeist.StoneTablet:Mixin.ExportableForm':
   abstract: true
-  superTypes:
-    'Neos.Neos:Content': true
-
   ui:
     inspector:
       groups:


### PR DESCRIPTION
Will close #9 

- [x] Remove `Neos.Neos:Content` `superType`
- [x] [Rename `title` to `formTitle` and make it optional. if not set fallback to `node.label`
- [x]  Re-sort properties in the inspector, hide `formTitle` and `excludedFields` if `isExportable` is not `true`